### PR TITLE
[기능] 사용자 프로필 관련 API 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
+        "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/passport": "^11.0.5",
@@ -2479,6 +2480,21 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.2.tgz",
+      "integrity": "sha512-McMW6EXtpc8+CwTUwFdg6h7dYcBUpH5iUILCclAsa+MbCEvC9ZKu4dCHRlJqALuhjLw97pbQu62l4+wRwGeZqA==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "16.4.7",
+        "dotenv-expand": "12.0.1",
+        "lodash": "4.17.21"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "rxjs": "^7.1.0"
       }
     },
     "node_modules/@nestjs/core": {
@@ -6151,6 +6167,33 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.1.tgz",
+      "integrity": "sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
+    "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",

--- a/prisma/migrations/20250609104232_init/migration.sql
+++ b/prisma/migrations/20250609104232_init/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[email]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `email` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "email" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,99 +8,107 @@ datasource db {
 }
 
 model User {
-  id            String   @id
+  id            String          @id
+  email         String          @unique
   password      String
   nickname      String
-  favorite_team String?
-  created_at    DateTime @default(now())
+  favoriteTeam  String?         @map("favorite_team")
+  createdAt     DateTime        @default(now()) @map("created_at")
   posts         Post[]
   comments      Comment[]
-  postLikes     PostLike[]
-  commentLikes  CommentLike[]
+  postLikes     PostLike[]      
+  commentLikes  CommentLike[]  
 }
 
 model Post {
   id         Int           @id @default(autoincrement())
-  user_id    String
+  userId     String        @map("user_id")
   title      String
   content    String
-  likes_count Int          @default(0)
-  created_at DateTime      @default(now())
-  updated_at DateTime      @updatedAt
-  user       User          @relation(fields: [user_id], references: [id])
+  likesCount Int           @default(0) @map("likes_count")
+  createdAt  DateTime      @default(now()) @map("created_at")
+  updatedAt  DateTime      @updatedAt      @map("updated_at")
+
+  user       User          @relation(fields: [userId], references: [id])
   comments   Comment[]
   likes      PostLike[]
 }
 
 model Comment {
   id         Int           @id @default(autoincrement())
-  post_id    Int
-  user_id    String
+  postId     Int           @map("post_id")
+  userId     String        @map("user_id")
   content    String
-  likes_count Int          @default(0)
-  created_at DateTime      @default(now())
-  post       Post          @relation(fields: [post_id], references: [id])
-  user       User          @relation(fields: [user_id], references: [id])
+  likesCount Int           @default(0) @map("likes_count")
+  createdAt  DateTime      @default(now()) @map("created_at")
+
+  post       Post          @relation(fields: [postId], references: [id])
+  user       User          @relation(fields: [userId], references: [id])
   likes      CommentLike[]
 }
 
 model PostLike {
   id         Int       @id @default(autoincrement())
-  post_id    Int
-  user_id    String
-  created_at DateTime  @default(now())
-  post       Post      @relation(fields: [post_id], references: [id])
-  user       User      @relation(fields: [user_id], references: [id])
+  postId     Int       @map("post_id")
+  userId     String    @map("user_id")
+  createdAt  DateTime  @default(now()) @map("created_at")
+
+  post       Post      @relation(fields: [postId], references: [id])
+  user       User      @relation(fields: [userId], references: [id])
 }
 
 model CommentLike {
   id         Int       @id @default(autoincrement())
-  comment_id Int
-  user_id    String
-  created_at DateTime  @default(now())
-  comment    Comment   @relation(fields: [comment_id], references: [id])
-  user       User      @relation(fields: [user_id], references: [id])
+  commentId  Int       @map("comment_id")
+  userId     String    @map("user_id")
+  createdAt  DateTime  @default(now()) @map("created_at")
+
+  comment    Comment   @relation(fields: [commentId], references: [id])
+  user       User      @relation(fields: [userId], references: [id])
 }
 
 model Team {
-  id       Int       @id @default(autoincrement())
-  name     String
-  location String
-  stadium  String
-  logo_url String
-  players  Player[]
-  home_games Game[]   @relation("HomeGames")
-  away_games Game[]   @relation("AwayGames")
-  news     News[]
+  id        Int       @id @default(autoincrement())
+  name      String
+  location  String
+  stadium   String
+  logoUrl   String     @map("logo_url")
+  players   Player[]
+  homeGames Game[]     @relation("HomeGames")
+  awayGames Game[]     @relation("AwayGames")
+  news      News[]
 }
 
 model Player {
-  id        Int      @id @default(autoincrement())
-  team_id   Int
-  name      String
-  position  String
-  stats_json Json
-  team      Team     @relation(fields: [team_id], references: [id])
+  id         Int      @id @default(autoincrement())
+  teamId     Int      @map("team_id")
+  name       String
+  position   String
+  statsJson  Json     @map("stats_json")
+
+  team       Team     @relation(fields: [teamId], references: [id])
 }
 
 model Game {
-  id            Int       @id @default(autoincrement())
-  home_team_id  Int
-  away_team_id  Int
-  game_date     DateTime
-  stadium       String
-  result_json   Json
-  home_team     Team      @relation("HomeGames", fields: [home_team_id], references: [id])
-  away_team     Team      @relation("AwayGames", fields: [away_team_id], references: [id])
+  id           Int      @id @default(autoincrement())
+  homeTeamId   Int      @map("home_team_id")
+  awayTeamId   Int      @map("away_team_id")
+  gameDate     DateTime @map("game_date")
+  stadium      String
+  resultJson   Json     @map("result_json")
+
+  homeTeam     Team     @relation("HomeGames", fields: [homeTeamId], references: [id])
+  awayTeam     Team     @relation("AwayGames", fields: [awayTeamId], references: [id])
 }
 
 model News {
-  id              Int       @id @default(autoincrement())
-  title           String
-  content_url     String
-  thumbnail_url   String
-  source          String
-  published_at    DateTime
-  related_team_id Int
-  team            Team      @relation(fields: [related_team_id], references: [id])
+  id             Int      @id @default(autoincrement())
+  title          String
+  contentUrl     String   @map("content_url")
+  thumbnailUrl   String   @map("thumbnail_url")
+  source         String
+  publishedAt    DateTime @map("published_at")
+  relatedTeamId  Int      @map("related_team_id")
+
+  team           Team     @relation(fields: [relatedTeamId], references: [id])
 }

--- a/src/auth/jwt-auth.guard.ts
+++ b/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(config: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: config.get<string>('JWT_ACCESS_SECRET'),
+    });
+  }
+
+  async validate(payload: any) {
+    return { id: payload.sub, email: payload.email };
+  }
+}

--- a/src/user/dto/update-profile.dto.ts
+++ b/src/user/dto/update-profile.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateProfileDto {
+  @IsOptional()
+  @IsString()
+  nickname?: string;
+
+  @IsOptional()
+  @IsString()
+  favoriteTeam?: string;
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,42 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Patch, Delete, UseGuards, Body } from '@nestjs/common';
+import { UsersService } from './user.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { User as UserEntity } from '@prisma/client';
+import { User } from './user.decorator';
+import { UpdateProfileDto } from './dto/update-profile.dto';
 
-@Controller('user')
-export class UserController {}
+@UseGuards(JwtAuthGuard)
+@Controller('api/v1/profile')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get()
+  getProfile(@User() user: UserEntity) {
+    return this.usersService.getProfile(user.id);
+  }
+
+  @Patch()
+  updateProfile(@User() user: UserEntity, @Body() dto: UpdateProfileDto) {
+    return this.usersService.updateProfile(user.id, dto);
+  }
+
+  @Delete()
+  deleteAccount(@User() user: UserEntity) {
+    return this.usersService.deleteAccount(user.id);
+  }
+
+  @Get('posts')
+  getMyPosts(@User() user: UserEntity) {
+    return this.usersService.getMyPosts(user.id);
+  }
+
+  @Get('comments')
+  getMyComments(@User() user: UserEntity) {
+    return this.usersService.getMyComments(user.id);
+  }
+
+  @Get('likes')
+  getMyLikedPosts(@User() user: UserEntity) {
+    return this.usersService.getMyLikedPosts(user.id);
+  }
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Patch, Delete, UseGuards, Body } from '@nestjs/common';
-import { UsersService } from './user.service';
+import { UserService } from './user.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { User as UserEntity } from '@prisma/client';
 import { User } from './user.decorator';
@@ -7,8 +7,8 @@ import { UpdateProfileDto } from './dto/update-profile.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('api/v1/profile')
-export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+export class UserController {
+  constructor(private readonly usersService: UserService) {}
 
   @Get()
   getProfile(@User() user: UserEntity) {

--- a/src/user/user.decorator.ts
+++ b/src/user/user.decorator.ts
@@ -1,0 +1,6 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const User = createParamDecorator((_: unknown, ctx: ExecutionContext) => {
+  const request = ctx.switchToHttp().getRequest();
+  return request.user;
+});

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,4 +1,61 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { UpdateProfileDto } from './dto/update-profile.dto';
 
 @Injectable()
-export class UserService {}
+export class UsersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getProfile(userId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        email: true,
+        nickname: true,
+        favoriteTeam: true,
+      },
+    });
+    if (!user) throw new NotFoundException('User not found');
+    return user;
+  }
+
+  async updateProfile(userId: string, dto: UpdateProfileDto) {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        nickname: dto.nickname,
+        favoriteTeam: dto.favoriteTeam,
+      },
+    });
+  }
+
+  async deleteAccount(userId: string) {
+    await this.prisma.user.delete({
+      where: { id: userId },
+    });
+  }
+
+  async getMyPosts(userId: string) {
+    return this.prisma.post.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async getMyComments(userId: string) {
+    return this.prisma.comment.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async getMyLikedPosts(userId: string) {
+    return this.prisma.postLike.findMany({
+      where: { userId },
+      include: {
+        post: true,
+      },
+    });
+  }
+}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -3,7 +3,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 
 @Injectable()
-export class UsersService {
+export class UserService {
   constructor(private readonly prisma: PrismaService) {}
 
   async getProfile(userId: string) {


### PR DESCRIPTION
## 작업 내용
- GET /api/v1/profile: 내 정보 조회
- PATCH /api/v1/profile: 닉네임/선호 구단 수정
- DELETE /api/v1/profile: 계정 삭제
- GET /api/v1/profile/posts: 내가 작성한 글 목록 조회
- GET /api/v1/profile/comments: 내가 작성한 댓글 목록 조회
- GET /api/v1/profile/likes: 내가 추천한 게시글 목록 조회
- DB단과 코드단의 네이밍 컨벤션 분리

## 참고 사항
- JWT 인증이 필수이며 @User 데코레이터로 사용자 ID 식별
- 추후 닉네임 중복 체크 등 API 확장 필요
- DB단과 코드단의 네이밍 컨벤션 분리 구분
