### PR TITLE
[기능] 댓글 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,10 +9,13 @@ import { HighlightModule } from './highlight/highlight.module';
 import { ScheduleModule } from './schedule/schedule.module';
 import { ConfigModule } from './config/config.module';
 import { PrismaModule } from './prisma/prisma.module';
+import { CommentController } from './comment/comment.controller';
+import { ServiceController } from './service/service.controller';
+import { CommentService } from './comment/comment.service';
 
 @Module({
   imports: [UserModule, PostModule, AuthModule, BaseballModule, HighlightModule, ScheduleModule, ConfigModule, PrismaModule],
-  controllers: [AppController],
-  providers: [AppService],
+  controllers: [AppController, CommentController, ServiceController],
+  providers: [AppService, CommentService],
 })
 export class AppModule {}

--- a/src/comment/comment.controller.spec.ts
+++ b/src/comment/comment.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentController } from './comment.controller';
+
+describe('CommentController', () => {
+  let controller: CommentController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CommentController],
+    }).compile();
+
+    controller = module.get<CommentController>(CommentController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('comment')
+export class CommentController {}

--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -1,4 +1,53 @@
-import { Controller } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+  Get,
+  ParseIntPipe,
+} from '@nestjs/common';
+import { CommentService } from './comment.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { UpdateCommentDto } from './dto/update-comment.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { User } from '../user/decorator/user.decorator';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 
-@Controller('comment')
-export class CommentController {}
+@ApiTags('댓글(Comment)')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('api/v1/comments')
+export class CommentController {
+  constructor(private readonly commentService: CommentService) {}
+
+  @Post()
+  @ApiOperation({ summary: '댓글 작성' })
+  create(@User('id') userId: string, @Body() dto: CreateCommentDto) {
+    return this.commentService.create(userId, dto);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: '댓글 수정' })
+  update(
+    @User('id') userId: string,
+    @Param('id', ParseIntPipe) commentId: number,
+    @Body() dto: UpdateCommentDto,
+  ) {
+    return this.commentService.update(userId, commentId, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: '댓글 삭제' })
+  delete(@User('id') userId: string, @Param('id', ParseIntPipe) commentId: number) {
+    return this.commentService.delete(userId, commentId);
+  }
+
+  @Get('post/:postId')
+  @ApiOperation({ summary: '게시글의 댓글 목록 조회' })
+  findByPost(@Param('postId', ParseIntPipe) postId: number) {
+    return this.commentService.findByPost(postId);
+  }
+}

--- a/src/comment/comment.service.spec.ts
+++ b/src/comment/comment.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentService } from './comment.service';
+
+describe('CommentService', () => {
+  let service: CommentService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CommentService],
+    }).compile();
+
+    service = module.get<CommentService>(CommentService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CommentService {}

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -1,4 +1,56 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { UpdateCommentDto } from './dto/update-comment.dto';
+import { BusinessException } from '../common/exceptions/business.exception';
+import { ErrorCode } from '../common/constants/error-code';
+import { ErrorMessage } from '../common/constants/error-message';
 
 @Injectable()
-export class CommentService {}
+export class CommentService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(userId: string, dto: CreateCommentDto) {
+    const post = await this.prisma.post.findUnique({ where: { id: dto.postId } });
+    if (!post) {
+      throw new BusinessException(ErrorCode.POST_NOT_FOUND, ErrorMessage.POST_NOT_FOUND);
+    }
+
+    return this.prisma.comment.create({
+      data: {
+        content: dto.content,
+        postId: dto.postId,
+        userId,
+      },
+    });
+  }
+
+  async update(userId: string, commentId: number, dto: UpdateCommentDto) {
+    const comment = await this.prisma.comment.findUnique({ where: { id: commentId } });
+    if (!comment || comment.userId !== userId) {
+      throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND, ErrorMessage.COMMENT_NOT_FOUND);
+    }
+
+    return this.prisma.comment.update({
+      where: { id: commentId },
+      data: { content: dto.content },
+    });
+  }
+
+  async delete(userId: string, commentId: number) {
+    const comment = await this.prisma.comment.findUnique({ where: { id: commentId } });
+    if (!comment || comment.userId !== userId) {
+      throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND, ErrorMessage.COMMENT_NOT_FOUND);
+    }
+
+    return this.prisma.comment.delete({ where: { id: commentId } });
+  }
+
+  async findByPost(postId: number) {
+    return this.prisma.comment.findMany({
+      where: { postId },
+      include: { user: true },
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+}

--- a/src/comment/dto/create-comment.dto.ts
+++ b/src/comment/dto/create-comment.dto.ts
@@ -1,0 +1,10 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateCommentDto {
+  @IsNotEmpty()
+  @IsString()
+  content: string;
+
+  @IsNotEmpty()
+  postId: number;
+}

--- a/src/comment/dto/update-comment.dto.ts
+++ b/src/comment/dto/update-comment.dto.ts
@@ -1,0 +1,7 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateCommentDto {
+  @IsOptional()
+  @IsString()
+  content?: string;
+}

--- a/src/common/constants/error-code.ts
+++ b/src/common/constants/error-code.ts
@@ -7,6 +7,8 @@ export const ErrorCode = {
   POST_NOT_FOUND: 'POST_NOT_FOUND',
   NO_PERMISSION: 'NO_PERMISSION',
   ALREADY_LIKED: 'ALREADY_LIKED',
+
+  COMMENT_NOT_FOUND: 'COMMENT_NOT_FOUND',
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/src/common/constants/error-message.ts
+++ b/src/common/constants/error-message.ts
@@ -6,4 +6,6 @@ export enum ErrorMessage {
   POST_NOT_FOUND = '게시글을 찾을 수 없습니다.',
   ALREADY_LIKED = '이미 추천한 게시글입니다.',
   NO_PERMISSION = '해당 작업을 수행할 권한이 없습니다.',
+
+  COMMENT_NOT_FOUND = '댓글을 찾을 수 없습니다.',
 }


### PR DESCRIPTION
## 작업 내용
- 댓글 생성, 수정, 삭제, 게시글별 댓글 조회 기능 구현
- Swagger 문서화 (@ApiTags, @ApiOperation, @ApiBearerAuth 등)

## 참고 사항
- `postId`가 존재하지 않으면 `POST_NOT_FOUND` 예외 발생
- 본인이 작성한 댓글이 아니면 `COMMENT_NOT_FOUND` 예외 발생
- 추후 대댓글, 좋아요 기능 확장..?
