### PR TITLE
[설정] GitHub Actions 기반 CI/CD 배포 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,32 +1,36 @@
-name: Deploy to EC2
+name: Deploy to EC2 (Dev)
 
 on:
   push:
-    branches: [main]
+    branches:
+      - dev
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout source
+      - name: Checkout source code
         uses: actions/checkout@v3
 
-      - name: Set up SSH key
+      - name: Add SSH private key
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.EC2_KEY }}" > ~/.ssh/id_rsa
+          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
 
-      - name: Add EC2 to known hosts
+      - name: Add known hosts
         run: |
           ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
 
-      - name: Deploy to EC2 via SSH
+      - name: Copy files to EC2
         run: |
-          ssh ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << 'EOF'
-            cd /home/${{ secrets.EC2_USERNAME }}/my-kbo-server
-            git pull origin main
-            docker compose down
-            docker compose up --build -d
+          rsync -avz -e "ssh -i ~/.ssh/id_rsa" ./ ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USERNAME }}/server
+
+      - name: Run Docker Compose on EC2
+        run: |
+          ssh -i ~/.ssh/id_rsa ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << 'EOF'
+            cd $(dirname "${{ secrets.DOCKER_COMPOSE_PATH }}")
+            docker compose down || true
+            docker compose up -d --build
           EOF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to EC2
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.EC2_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+
+      - name: Add EC2 to known hosts
+        run: |
+          ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Deploy to EC2 via SSH
+        run: |
+          ssh ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << 'EOF'
+            cd /home/${{ secrets.EC2_USERNAME }}/my-kbo-server
+            git pull origin main
+            docker compose down
+            docker compose up --build -d
+          EOF


### PR DESCRIPTION
## 작업 내용
- GitHub Actions 워크플로 파일(`.github/workflows/deploy.yml`) 추가
- EC2 인스턴스에 SSH 접속 후 Docker Compose로 서버 배포되는 자동화 스크립트 구성

## 변경 사항
- 배포 브랜치: `dev`
- 포트: 3456
- 경로: `/home/ubuntu/server/docker-compose.yml`

## 참고 사항
- GitHub Actions에 다음 Secrets 등록됨:
  - `EC2_HOST`, `EC2_USERNAME`, `EC2_KEY`, `DOCKER_COMPOSE_PATH`
- Docker 및 Docker Compose는 EC2 인스턴스에 사전 설치 완료됨

## 테스트
- dev 브랜치 푸시 시 자동 배포 확인
- 필요 시 main 브랜치용 프로덕션 배포 워크플로 추가 예정
