### PR TITLE
[리팩토링] Auth 도메인 전체 리팩토링 (JWT 인증 및 토큰 재발급 개선)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.2.0",
         "@prisma/client": "^6.9.0",
+        "@types/cookie-parser": "^1.4.9",
         "bcrypt": "^6.0.0",
         "class-validator": "^0.14.2",
         "passport": "^0.7.0",
@@ -3398,7 +3399,6 @@
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -3409,10 +3409,18 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cookiejar": {
@@ -3455,7 +3463,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.2.tgz",
       "integrity": "sha512-BtjL3ZwbCQriyb0DGw+Rt12qAXPiBTPs815lsUvtt1Grk0vLRMZNMUZ741d5rjk+UQOxfDiBZ3dxpX00vSkK3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -3467,7 +3474,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
       "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -3497,7 +3503,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -3565,7 +3570,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -3581,21 +3585,18 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -3606,7 +3607,6 @@
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
       "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.0",
     "@prisma/client": "^6.9.0",
+    "@types/cookie-parser": "^1.4.9",
     "bcrypt": "^6.0.0",
     "class-validator": "^0.14.2",
     "passport": "^0.7.0",

--- a/prisma/migrations/20250629070926_add_refresh_token_to_user/migration.sql
+++ b/prisma/migrations/20250629070926_add_refresh_token_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "refresh_token" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model User {
   nickname       String
   favoriteTeam   String?  @map("favorite_team")
   createdAt      DateTime @default(now()) @map("created_at")
+  refreshToken String?  @map("refresh_token")
 
   posts          Post[]
   comments       Comment[]

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,6 +4,7 @@ import { AuthService } from './auth.service';
 import { SignupDto } from './dto/signup.dto';
 import { LoginDto } from './dto/login.dto';
 import { Response, Request } from 'express';
+import { User } from 'src/user/decorator/user.decorator';
 
 @ApiTags('Auth')
 @Controller('api/v1/auth')
@@ -33,9 +34,12 @@ export class AuthController {
 
   @Post('refresh')
   @ApiOperation({ summary: 'Access Token 재발급' })
-  async refresh(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+  async refresh(
+    @User('id') userId: string,
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
     const oldRefreshToken = req.cookies['refreshToken'];
-    const userId = (req as any).user?.sub;
 
     const { accessToken, refreshToken } = await this.authService.refresh(userId, oldRefreshToken);
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,8 +1,9 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Res, Req } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { SignupDto } from './dto/signup.dto';
 import { LoginDto } from './dto/login.dto';
+import { Response, Request } from 'express';
 
 @ApiTags('Auth')
 @Controller('api/v1/auth')
@@ -17,7 +18,43 @@ export class AuthController {
 
   @Post('login')
   @ApiOperation({ summary: '로그인' })
-  login(@Body() dto: LoginDto) {
-    return this.authService.login(dto);
+  async login(@Body() dto: LoginDto, @Res({ passthrough: true }) res: Response) {
+    const { accessToken, refreshToken } = await this.authService.login(dto);
+
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      path: '/api/v1/auth/refresh',
+      sameSite: 'strict',
+      secure: true,
+    });
+
+    return { accessToken };
+  }
+
+  @Post('refresh')
+  @ApiOperation({ summary: 'Access Token 재발급' })
+  async refresh(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    const oldRefreshToken = req.cookies['refreshToken'];
+    const userId = (req as any).user?.sub;
+
+    const { accessToken, refreshToken } = await this.authService.refresh(userId, oldRefreshToken);
+
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      path: '/api/v1/auth/refresh',
+      sameSite: 'strict',
+      secure: true,
+    });
+
+    return { accessToken };
+  }
+
+  @Post('logout')
+  @ApiOperation({ summary: '로그아웃' })
+  async logout(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    const oldRefreshToken = req.cookies?.refreshToken;
+    await this.authService.logout(oldRefreshToken);
+    res.clearCookie('refreshToken');
+    return { message: 'Logout success' };
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -71,8 +71,8 @@ export class AuthService {
 
     if (!user || user.refreshToken !== oldRefreshToken) {
       throw new BusinessException(
-        ErrorCode.Auth.INVALID_REFRESH_TOKEN,
-        ErrorMessage.Auth.INVALID_REFRESH_TOKEN,
+        ErrorCode.User.INVALID_REFRESH_TOKEN,
+        ErrorMessage.User.INVALID_REFRESH_TOKEN,
       );
     }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../prisma/prisma.service';
@@ -34,7 +34,7 @@ export class AuthService {
     };
   }
 
-  async login(dto: LoginDto): Promise<{ accessToken: string }> {
+  async login(dto: LoginDto): Promise<{ accessToken: string; refreshToken: string }> {
     const user = await this.prisma.user.findUnique({
       where: { email: dto.email },
     });
@@ -52,8 +52,52 @@ export class AuthService {
     }
 
     const payload = { sub: user.id };
-    const accessToken = this.jwtService.sign(payload);
-    return { accessToken };
+
+    const accessToken = this.jwtService.sign(payload, { expiresIn: '15m' });
+    const refreshToken = this.jwtService.sign(payload, { expiresIn: '7d' });
+
+    await this.saveRefreshToken(user.id, refreshToken);
+
+    return { accessToken, refreshToken };
+  }
+
+  async refresh(
+    userId: string,
+    oldRefreshToken: string,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user || user.refreshToken !== oldRefreshToken) {
+      throw new BusinessException(
+        ErrorCode.Auth.INVALID_REFRESH_TOKEN,
+        ErrorMessage.Auth.INVALID_REFRESH_TOKEN,
+      );
+    }
+
+    const payload = { sub: userId };
+
+    const accessToken = this.jwtService.sign(payload, { expiresIn: '15m' });
+    const refreshToken = this.jwtService.sign(payload, { expiresIn: '7d' });
+
+    await this.saveRefreshToken(userId, refreshToken);
+
+    return { accessToken, refreshToken };
+  }
+
+  async logout(userId: string): Promise<void> {
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { refreshToken: null },
+    });
+  }
+
+  private async saveRefreshToken(userId: string, refreshToken: string): Promise<void> {
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { refreshToken },
+    });
   }
 
   private async hashPassword(password: string): Promise<string> {

--- a/src/common/constants/error/error-code.ts
+++ b/src/common/constants/error/error-code.ts
@@ -6,6 +6,7 @@ export const ErrorCode = {
     USER_NOT_FOUND: 'USER_001',
     INVALID_PASSWORD: 'USER_002',
     EMAIL_ALREADY_EXISTS: 'USER_003',
+    INVALID_REFRESH_TOKEN: 'USER_004',
   },
 
   Post: {

--- a/src/common/constants/error/error-message.ts
+++ b/src/common/constants/error/error-message.ts
@@ -3,6 +3,7 @@ export const ErrorMessage = {
     USER_NOT_FOUND: '사용자를 찾을 수 없습니다.',
     INVALID_PASSWORD: '비밀번호가 일치하지 않습니다.',
     EMAIL_ALREADY_EXISTS: '이미 존재하는 이메일입니다.',
+    INVALID_REFRESH_TOKEN: '유효하지 않은 리프레시 토큰입니다.',
   },
 
   Post: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AllExceptionsFilter } from './common/filters/http-exception.filter';
+import cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -14,7 +15,7 @@ async function bootstrap() {
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api-docs', app, document);
-
+  app.use(cookieParser());
   app.useGlobalFilters(new AllExceptionsFilter());
 
   await app.listen(3456);


### PR DESCRIPTION
### 작업 내용
#### AuthService
- login 시 accessToken, refreshToken 모두 발급하도록 수정
- refresh() 메서드 추가: 유효한 리프레시 토큰으로 새 토큰 재발급
- BusinessException 적용: 존재하지 않는 유저, 비밀번호 불일치, 토큰 불일치 등 예외 처리

#### AuthController
- refresh 엔드포인트 리팩토링:
- 사용자 ID: @User('id')로 추출
- refreshToken 미존재 시 예외 처리
- 재발급된 토큰을 cookie에 설정했음

#### 예외 상수 정리
- ErrorCode.Auth.REFRESH_TOKEN_REQUIRED 추가
- ErrorMessage.Auth.REFRESH_TOKEN_REQUIRED 추가

### 참고 사항
- HttpOnly, SameSite: 'strict', Secure 쿠키 설정 반영
- 추후 로그아웃 시 쿠키 제거 처리 필요