### PR TITLE
[기능] baseball 메인화면 API 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "bcrypt": "^6.0.0",
         "class-validator": "^0.14.2",
         "cookie-parser": "^1.4.7",
+        "date-fns": "^4.1.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
@@ -6037,6 +6038,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bcrypt": "^6.0.0",
     "class-validator": "^0.14.2",
     "cookie-parser": "^1.4.7",
+    "date-fns": "^4.1.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",

--- a/src/baseball/baseball.controller.spec.ts
+++ b/src/baseball/baseball.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BaseballController } from './baseball.controller';
+
+describe('BaseballController', () => {
+  let controller: BaseballController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BaseballController],
+    }).compile();
+
+    controller = module.get<BaseballController>(BaseballController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/baseball/baseball.controller.ts
+++ b/src/baseball/baseball.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('baseball')
+export class BaseballController {}

--- a/src/baseball/baseball.controller.ts
+++ b/src/baseball/baseball.controller.ts
@@ -1,4 +1,30 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { BaseballService } from './baseball.service';
 
-@Controller('baseball')
-export class BaseballController {}
+@ApiTags('baseball')
+@Controller('api/v1/baseball')
+export class BaseballController {
+  constructor(private readonly baseballService: BaseballService) {}
+
+  @ApiOperation({ summary: '전체 팀 순위' })
+  @ApiResponse({ status: 200, type: [GetTeamRankingResponseDto] })
+  @Get('rankings')
+  async getTeamRankings() {
+    return this.baseballService.getTeamRankings();
+  }
+
+  @ApiOperation({ summary: '플레이어 순위 (타자/투수)' })
+  @ApiResponse({ status: 200, type: [GetTopPlayerResponseDto] })
+  @Get('topplayer')
+  async getTopPlayers() {
+    return this.baseballService.getTopPlayers();
+  }
+
+  @ApiOperation({ summary: '오늘의 경기 일정' })
+  @ApiResponse({ status: 200, type: [GetTodayGameResponseDto] })
+  @Get('games/today')
+  async getTodayGames() {
+    return this.baseballService.getTodayGames();
+  }
+}

--- a/src/baseball/baseball.controller.ts
+++ b/src/baseball/baseball.controller.ts
@@ -3,6 +3,7 @@ import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { BaseballService } from './baseball.service';
 import { TeamRankingDto } from './dto/team-ranking.dto';
 import { GetTopPlayersResponseDto } from './dto/top-player.dto';
+import { TodayGameDto } from './dto/today-games.dto';
 
 @ApiTags('baseball')
 @Controller('api/v1/baseball')
@@ -21,5 +22,12 @@ export class BaseballController {
   @ApiResponse({ status: 200, type: GetTopPlayersResponseDto })
   async getTopPlayers(): Promise<GetTopPlayersResponseDto> {
     return this.baseballService.getTopPlayers();
+  }
+
+  @Get('games/today')
+  @ApiOperation({ summary: '오늘의 경기 일정 조회' })
+  @ApiResponse({ status: 200, description: '성공', type: [TodayGameDto] })
+  async getTodayGames(): Promise<TodayGameDto[]> {
+    return this.baseballService.getTodayGames();
   }
 }

--- a/src/baseball/baseball.controller.ts
+++ b/src/baseball/baseball.controller.ts
@@ -1,30 +1,25 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { BaseballService } from './baseball.service';
+import { TeamRankingDto } from './dto/team-ranking.dto';
+import { GetTopPlayersResponseDto } from './dto/top-player.dto';
 
 @ApiTags('baseball')
 @Controller('api/v1/baseball')
 export class BaseballController {
   constructor(private readonly baseballService: BaseballService) {}
 
-  @ApiOperation({ summary: '전체 팀 순위' })
-  @ApiResponse({ status: 200, type: [GetTeamRankingResponseDto] })
   @Get('rankings')
-  async getTeamRankings() {
+  @ApiOperation({ summary: '전체 팀 순위 조회' })
+  @ApiResponse({ status: 200, description: '성공', type: [TeamRankingDto] })
+  async getRankings(): Promise<TeamRankingDto[]> {
     return this.baseballService.getTeamRankings();
   }
 
-  @ApiOperation({ summary: '플레이어 순위 (타자/투수)' })
-  @ApiResponse({ status: 200, type: [GetTopPlayerResponseDto] })
   @Get('topplayer')
-  async getTopPlayers() {
+  @ApiOperation({ summary: '플레이어 1위 랭킹' })
+  @ApiResponse({ status: 200, type: GetTopPlayersResponseDto })
+  async getTopPlayers(): Promise<GetTopPlayersResponseDto> {
     return this.baseballService.getTopPlayers();
-  }
-
-  @ApiOperation({ summary: '오늘의 경기 일정' })
-  @ApiResponse({ status: 200, type: [GetTodayGameResponseDto] })
-  @Get('games/today')
-  async getTodayGames() {
-    return this.baseballService.getTodayGames();
   }
 }

--- a/src/baseball/baseball.module.ts
+++ b/src/baseball/baseball.module.ts
@@ -1,4 +1,9 @@
 import { Module } from '@nestjs/common';
+import { BaseballController } from './baseball.controller';
+import { BaseballService } from './baseball.service';
 
-@Module({})
+@Module({
+  controllers: [BaseballController],
+  providers: [BaseballService]
+})
 export class BaseballModule {}

--- a/src/baseball/baseball.service.spec.ts
+++ b/src/baseball/baseball.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BaseballService } from './baseball.service';
+
+describe('BaseballService', () => {
+  let service: BaseballService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BaseballService],
+    }).compile();
+
+    service = module.get<BaseballService>(BaseballService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/baseball/baseball.service.ts
+++ b/src/baseball/baseball.service.ts
@@ -2,6 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { GetTopPlayersResponseDto, TopPlayerDto } from './dto/top-player.dto';
 import { TeamRankingDto } from './dto/team-ranking.dto';
+import { TodayGameDto } from './dto/today-games.dto';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
 
 @Injectable()
 export class BaseballService {
@@ -46,6 +49,27 @@ export class BaseballService {
       winRate: r.winRate,
       gameGap: r.gameGap,
       streak: r.streak,
+    }));
+  }
+  async getTodayGames(): Promise<TodayGameDto[]> {
+    const now = new Date();
+    const todayFormatted = format(now, 'MM.dd(eee)', { locale: ko });
+
+    const games = await this.prisma.schedule.findMany({
+      where: { date: todayFormatted },
+      orderBy: { time: 'asc' },
+    });
+
+    return games.map((g) => ({
+      date: g.date,
+      time: g.time,
+      homeTeam: g.homeTeam,
+      homeScore: g.homeScore,
+      awayTeam: g.awayTeam,
+      awayScore: g.awayScore,
+      stadium: g.stadium,
+      tv: g.tv,
+      note: g.note,
     }));
   }
 }

--- a/src/baseball/baseball.service.ts
+++ b/src/baseball/baseball.service.ts
@@ -1,4 +1,36 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 @Injectable()
-export class BaseballService {}
+export class BaseballService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getTeamRankings(): Promise<GetTeamRankingResponseDto[]> {
+    const data = await this.prisma.teamRanking.findMany({ orderBy: { rank: 'asc' } });
+    return data;
+  }
+
+  async getTopPlayers(): Promise<GetTopPlayerResponseDto[]> {
+    const hitters = await this.prisma.playerStat.findMany({
+      where: { category: '타자' },
+      orderBy: { value: 'desc' },
+      take: 5,
+    });
+
+    const pitchers = await this.prisma.playerStat.findMany({
+      where: { category: '투수' },
+      orderBy: { value: 'asc' },
+      take: 5,
+    });
+
+    return [...hitters, ...pitchers];
+  }
+
+  async getTodayGames(): Promise<GetTodayGameResponseDto[]> {
+    const todayStr = new Date().toISOString().slice(0, 10);
+    return await this.prisma.schedule.findMany({
+      where: { date: todayStr },
+      orderBy: { time: 'asc' },
+    });
+  }
+}

--- a/src/baseball/baseball.service.ts
+++ b/src/baseball/baseball.service.ts
@@ -1,36 +1,51 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { GetTopPlayersResponseDto, TopPlayerDto } from './dto/top-player.dto';
+import { TeamRankingDto } from './dto/team-ranking.dto';
 
 @Injectable()
 export class BaseballService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async getTeamRankings(): Promise<GetTeamRankingResponseDto[]> {
-    const data = await this.prisma.teamRanking.findMany({ orderBy: { rank: 'asc' } });
-    return data;
+  async getTopPlayers(): Promise<GetTopPlayersResponseDto> {
+    const categories = ['타율', '홈런', '평균자책점', '승리'];
+
+    const result: TopPlayerDto[] = await Promise.all(
+      categories.map(async (category) => {
+        const player = await this.prisma.playerStat.findFirst({
+          where: { category },
+          orderBy: { value: category === '평균자책점' ? 'asc' : 'desc' },
+        });
+
+        return {
+          category,
+          name: player?.name ?? '',
+          team: player?.team ?? '',
+          value: player?.value ?? '',
+        };
+      }),
+    );
+
+    return {
+      hitter: result.filter((r) => r.category === '타율' || r.category === '홈런'),
+      pitcher: result.filter((r) => r.category === '평균자책점' || r.category === '승리'),
+    };
   }
-
-  async getTopPlayers(): Promise<GetTopPlayerResponseDto[]> {
-    const hitters = await this.prisma.playerStat.findMany({
-      where: { category: '타자' },
-      orderBy: { value: 'desc' },
-      take: 5,
+  async getTeamRankings(): Promise<TeamRankingDto[]> {
+    const rankings = await this.prisma.teamRank.findMany({
+      orderBy: { rank: 'asc' },
     });
 
-    const pitchers = await this.prisma.playerStat.findMany({
-      where: { category: '투수' },
-      orderBy: { value: 'asc' },
-      take: 5,
-    });
-
-    return [...hitters, ...pitchers];
-  }
-
-  async getTodayGames(): Promise<GetTodayGameResponseDto[]> {
-    const todayStr = new Date().toISOString().slice(0, 10);
-    return await this.prisma.schedule.findMany({
-      where: { date: todayStr },
-      orderBy: { time: 'asc' },
-    });
+    return rankings.map((r) => ({
+      rank: r.rank,
+      team: r.team,
+      games: r.games,
+      win: r.win,
+      lose: r.lose,
+      draw: r.draw,
+      winRate: r.winRate,
+      gameGap: r.gameGap,
+      streak: r.streak,
+    }));
   }
 }

--- a/src/baseball/baseball.service.ts
+++ b/src/baseball/baseball.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class BaseballService {}

--- a/src/baseball/dto/team-ranking.dto.ts
+++ b/src/baseball/dto/team-ranking.dto.ts
@@ -1,0 +1,11 @@
+export class TeamRankingDto {
+  rank: number;
+  team: string;
+  games: number;
+  win: number;
+  lose: number;
+  draw: number;
+  winRate: number;
+  gameGap: string;
+  streak: string;
+}

--- a/src/baseball/dto/today-games.dto.ts
+++ b/src/baseball/dto/today-games.dto.ts
@@ -1,0 +1,11 @@
+export class TodayGameDto {
+  date: string;
+  time: string;
+  homeTeam: string;
+  homeScore?: string;
+  awayTeam: string;
+  awayScore?: string;
+  stadium: string;
+  tv: string;
+  note?: string;
+}

--- a/src/baseball/dto/top-player.dto.ts
+++ b/src/baseball/dto/top-player.dto.ts
@@ -1,0 +1,11 @@
+export class TopPlayerDto {
+  category: string;
+  name: string;
+  team: string;
+  value: string;
+}
+
+export class GetTopPlayersResponseDto {
+  hitter: TopPlayerDto[];
+  pitcher: TopPlayerDto[];
+}


### PR DESCRIPTION
## 작업 내용
- `/api/v1/baseball/rankings` 전체 팀 순위 API 구현
- `/api/v1/baseball/topplayer` 타자/투수 순위 API 구현 (상위 5인)
- `/api/v1/baseball/games/today` 오늘 경기 일정 조회 API 구현

## 참고 사항
- DTO 기반으로 설계
- 크롤링된 데이터는 사전 DB 저장됨 (API는 조회만 수행)