### PR TITLE
[기능] 팀 대시보드 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,7 +5,6 @@ import { UserModule } from './user/user.module';
 import { PostModule } from './post/post.module';
 import { AuthModule } from './auth/auth.module';
 import { BaseballModule } from './baseball/baseball.module';
-import { HighlightModule } from './highlight/highlight.module';
 import { ScheduleModule } from './schedule/schedule.module';
 import { ConfigModule } from './config/config.module';
 import { PrismaModule } from './prisma/prisma.module';
@@ -18,7 +17,6 @@ import { TeamModule } from './team/team.module';
     PostModule,
     AuthModule,
     BaseballModule,
-    HighlightModule,
     ScheduleModule,
     ConfigModule,
     PrismaModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { ScheduleModule } from './schedule/schedule.module';
 import { ConfigModule } from './config/config.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { CommentModule } from './comment/comment.module';
+import { TeamModule } from './team/team.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { CommentModule } from './comment/comment.module';
     ConfigModule,
     PrismaModule,
     CommentModule,
+    TeamModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/highlight/highlight.module.ts
+++ b/src/highlight/highlight.module.ts
@@ -1,4 +1,0 @@
-import { Module } from '@nestjs/common';
-
-@Module({})
-export class HighlightModule {}

--- a/src/team/dto/team-hot-post.dto.ts
+++ b/src/team/dto/team-hot-post.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TeamHotPostDto {
+  @ApiProperty({ example: '김팬' })
+  nickname: string;
+
+  @ApiProperty({ example: '정말 최고의 팀입니다!' })
+  title: string;
+}

--- a/src/team/team.controller.spec.ts
+++ b/src/team/team.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TeamController } from './team.controller';
+
+describe('TeamController', () => {
+  let controller: TeamController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TeamController],
+    }).compile();
+
+    controller = module.get<TeamController>(TeamController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/team/team.controller.ts
+++ b/src/team/team.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('team')
+export class TeamController {}

--- a/src/team/team.controller.ts
+++ b/src/team/team.controller.ts
@@ -1,4 +1,16 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Param } from '@nestjs/common';
+import { TeamService } from './team.service';
+import { ApiTags, ApiOperation, ApiParam } from '@nestjs/swagger';
 
-@Controller('team')
-export class TeamController {}
+@ApiTags('Team Dashboard')
+@Controller('api/v1/teams')
+export class TeamController {
+  constructor(private readonly teamService: TeamService) {}
+
+  @Get(':teamName/schedule')
+  @ApiOperation({ summary: '팀별 향후 4경기 일정 조회' })
+  @ApiParam({ name: 'teamName', example: 'LG' })
+  getUpcomingSchedule(@Param('teamName') teamName: string) {
+    return this.teamService.getUpcomingSchedule(teamName);
+  }
+}

--- a/src/team/team.controller.ts
+++ b/src/team/team.controller.ts
@@ -19,4 +19,10 @@ export class TeamController {
   getRecentResults(@Param('teamName') teamName: string) {
     return this.teamService.getRecentResults(teamName);
   }
+  @Get(':teamName/topplayers')
+  @ApiOperation({ summary: '팀별 인기 선수 조회 (타자/투수)' })
+  @ApiParam({ name: 'teamName', example: 'LG' })
+  getTopPlayers(@Param('teamName') teamName: string) {
+    return this.teamService.getTopPlayers(teamName);
+  }
 }

--- a/src/team/team.controller.ts
+++ b/src/team/team.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { TeamService } from './team.service';
-import { ApiTags, ApiOperation, ApiParam } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiParam, ApiOkResponse } from '@nestjs/swagger';
+import { TeamHotPostDto } from './dto/team-hot-post.dto';
 
 @ApiTags('Team Dashboard')
 @Controller('api/v1/teams')
@@ -24,5 +25,11 @@ export class TeamController {
   @ApiParam({ name: 'teamName', example: 'LG' })
   getTopPlayers(@Param('teamName') teamName: string) {
     return this.teamService.getTopPlayers(teamName);
+  }
+  @Get(':teamName/hotposts')
+  @ApiOperation({ summary: '팀 응원글 상위 2개 조회' })
+  @ApiOkResponse({ type: [TeamHotPostDto] })
+  async getTeamHotPosts(@Param('teamName') teamName: string): Promise<TeamHotPostDto[]> {
+    return this.teamService.getHotPosts(teamName);
   }
 }

--- a/src/team/team.controller.ts
+++ b/src/team/team.controller.ts
@@ -13,4 +13,10 @@ export class TeamController {
   getUpcomingSchedule(@Param('teamName') teamName: string) {
     return this.teamService.getUpcomingSchedule(teamName);
   }
+  @Get(':teamName/results')
+  @ApiOperation({ summary: '팀별 최근 6경기 결과 조회' })
+  @ApiParam({ name: 'teamName', example: 'LG' })
+  getRecentResults(@Param('teamName') teamName: string) {
+    return this.teamService.getRecentResults(teamName);
+  }
 }

--- a/src/team/team.module.ts
+++ b/src/team/team.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TeamController } from './team.controller';
+import { TeamService } from './team.service';
+
+@Module({
+  controllers: [TeamController],
+  providers: [TeamService]
+})
+export class TeamModule {}

--- a/src/team/team.service.spec.ts
+++ b/src/team/team.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TeamService } from './team.service';
+
+describe('TeamService', () => {
+  let service: TeamService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TeamService],
+    }).compile();
+
+    service = module.get<TeamService>(TeamService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/team/team.service.ts
+++ b/src/team/team.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class TeamService {}

--- a/src/team/team.service.ts
+++ b/src/team/team.service.ts
@@ -60,4 +60,33 @@ export class TeamService {
 
     return recentGames;
   }
+  async getTopPlayers(teamName: string) {
+    const hitters = await this.prisma.teamTopPlayer.findFirst({
+      where: { team: teamName, type: '타자' },
+      orderBy: { id: 'desc' },
+    });
+
+    const pitchers = await this.prisma.teamTopPlayer.findFirst({
+      where: { team: teamName, type: '투수' },
+      orderBy: { id: 'desc' },
+    });
+
+    return {
+      타자: hitters
+        ? {
+            name: hitters.name,
+            game: hitters.game,
+            value: hitters.value,
+          }
+        : null,
+
+      투수: pitchers
+        ? {
+            name: pitchers.name,
+            game: pitchers.game,
+            value: pitchers.value,
+          }
+        : null,
+    };
+  }
 }

--- a/src/team/team.service.ts
+++ b/src/team/team.service.ts
@@ -1,4 +1,40 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { fetchWeatherByStadium } from '../common/weather/get-weather';
 
 @Injectable()
-export class TeamService {}
+export class TeamService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getUpcomingSchedule(teamName: string) {
+    const now = new Date();
+    const todayFormatted = format(now, 'MM.dd(eee)', { locale: ko });
+
+    const upcomingGames = await this.prisma.schedule.findMany({
+      where: {
+        OR: [{ homeTeam: teamName }, { awayTeam: teamName }],
+        date: {
+          gte: todayFormatted,
+        },
+      },
+      orderBy: { date: 'asc' },
+      take: 4,
+    });
+
+    const gamesWithWeather = await Promise.all(
+      upcomingGames.map(async (game) => {
+        const stadium = game.stadium;
+
+        const weather = await fetchWeatherByStadium(stadium);
+        return {
+          ...game,
+          weather,
+        };
+      }),
+    );
+
+    return gamesWithWeather;
+  }
+}

--- a/src/team/team.service.ts
+++ b/src/team/team.service.ts
@@ -37,4 +37,27 @@ export class TeamService {
 
     return gamesWithWeather;
   }
+  async getRecentResults(teamName: string) {
+    const now = new Date();
+    const todayFormatted = format(now, 'MM.dd(eee)', { locale: ko });
+
+    const recentGames = await this.prisma.schedule.findMany({
+      where: {
+        AND: [
+          {
+            OR: [{ homeTeam: teamName }, { awayTeam: teamName }],
+          },
+          {
+            date: {
+              lt: todayFormatted,
+            },
+          },
+        ],
+      },
+      orderBy: { date: 'desc' },
+      take: 6,
+    });
+
+    return recentGames;
+  }
 }


### PR DESCRIPTION
### 구현 사항
- 팀 일정, 팀 최근 결과, 팀 인기선수, 팀 응원 게시글 API 구현
- 크롤링된 데이터를 재사용함

### 참고 사항
- 응답 형식을 맞추어봐야 할 수 있음