### PR TITLE
[ 버그 ] 팀뉴스 : 관련없는 뉴스가 같이 나오는 문제 해결

### DIFF
--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -2,6 +2,12 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { NewsResponseDto } from './dto/news-response.dto';
 
+const teamNames = ['삼성', 'LG', 'SSG', 'NC', 'KIA', '한화', '두산', '키움', 'KT', '롯데'];
+
+function countTeamMentions(text: string): number {
+  return teamNames.reduce((count, team) => count + (text.includes(team) ? 1 : 0), 0);
+}
+
 @Injectable()
 export class NewsService {
   constructor(private readonly prisma: PrismaService) {}
@@ -16,15 +22,17 @@ export class NewsService {
   }
 
   async getTeamNews(teamName: string): Promise<NewsResponseDto[]> {
-    const news = await this.prisma.news.findMany({
-      where: {
-        OR: [{ title: { contains: teamName } }, { summary: { contains: teamName } }],
-      },
+    const allNews = await this.prisma.news.findMany({
       orderBy: { createdAt: 'asc' },
-      take: 5,
+      take: 80,
     });
 
-    return news.map(this.toDto);
+    const filtered = allNews.filter((item) => {
+      const title = item.title;
+      return title.includes(teamName) && countTeamMentions(title) === 1;
+    });
+
+    return filtered.slice(0, 5).map(this.toDto);
   }
 
   private toDto(news: any): NewsResponseDto {


### PR DESCRIPTION
### 구현 사항
- 필터를 적용해서 팀에 해당하는 뉴스만 나오도록 설정함